### PR TITLE
fix: changing wezterm toml to lua theme definition

### DIFF
--- a/extra/wezterm/tokyodak.lua
+++ b/extra/wezterm/tokyodak.lua
@@ -1,0 +1,33 @@
+-- tokyodark
+return {
+    foreground = "#a0a8cd",
+    background = "#11121d",
+
+    cursor_bg = "#a0a8cd",
+    cursor_fg = "#11121d",
+    cursor_border = "#a0a8cd",
+
+    selection_bg = "#11121d",
+    selection_fg = "#a0a8cd",
+
+    ansi = {
+        "#06080a",
+        "#ee6d85",
+        "#95c561",
+        "#d7a65f",
+        "#7199ee",
+        "#a485dd",
+        "#38a89d",
+        "#a0a8cd",
+    },
+    brights = {
+        "#212234",
+        "#ee6d85",
+        "#95c561",
+        "#d7a65f",
+        "#7199ee",
+        "#a485dd",
+        "#38a89d",
+        "#a0a8cd",
+    },
+}


### PR DESCRIPTION
Hi! I noticed wezterm was using a .toml extension, so I added a lua version to the directory so that users can just copy-paste