### PR TITLE
feat(extra): Add ghostty theme file

### DIFF
--- a/extra/ghostty/README.md
+++ b/extra/ghostty/README.md
@@ -1,0 +1,39 @@
+# Ghostty
+
+> "[Ghostty](https://ghostty.org/) is a fast, feature-rich, and cross-platform terminal emulator that uses platform-native UI and GPU acceleration." - Ghostty docs
+
+👻 To use tokyodark in Ghostty, you need to update your Ghostty config file.
+
+## Install guide
+
+Simply copy the `tokyodark` file into your `themes/` directory.
+If you don't have a `themes/` directory, create one next to your `config` file.
+
+Your Ghostty config directory structure should look something like this:
+
+```plaintext
+- ghostty/
+  - config
+  - themes/
+    - tokyodark
+```
+
+Then, in your `config` file, set `theme` to `tokyodark`:
+
+```ini
+theme = "tokyodark"
+```
+
+Reload your config and you should see the theme applied!
+
+### Note
+
+If you don't want to create a `themes/` directory, you can also use an absolute path:
+
+```ini
+theme = "../code/tokyodark.nvim/extra/ghostty/tokyodark" # or wherever your local tokyodark file is
+```
+
+## Need help?
+
+See the [Ghostty docs](https://ghostty.org/docs/config/reference#theme) for details.

--- a/extra/ghostty/tokyodark
+++ b/extra/ghostty/tokyodark
@@ -1,0 +1,22 @@
+palette = 0=#06080a
+palette = 1=#ee6d85
+palette = 2=#95c561
+palette = 3=#d7a65f
+palette = 4=#7199ee
+palette = 5=#a485dd
+palette = 6=#38a89d
+palette = 7=#a0a8cd
+palette = 8=#212234
+palette = 9=#ee6d85
+palette = 10=#95c561
+palette = 11=#d7a65f
+palette = 12=#7199ee
+palette = 13=#a485dd
+palette = 14=#38a89d
+palette = 15=#a0a8cd
+
+background = #11121d
+foreground = #a0a8cd
+cursor-color = #a0a8cd
+selection-background = #a0a8cd
+selection-foreground = #11121d


### PR DESCRIPTION
This PR adds a theme file for the recently released [Ghostty](https://ghostty.org/docs) to `/extra/`.

I used `extra/kitty`'s config as reference as the two are about identical. Also added a `README.md` with some simple instructions, happy to leave out if it's unnecessary. Love `tokyodark`, appreciate your work on it!